### PR TITLE
feat: add font and chromium build

### DIFF
--- a/.github/actions/docker-build.yml
+++ b/.github/actions/docker-build.yml
@@ -1,0 +1,42 @@
+name: "Docker build"
+description: "Build docker html2pdf-service image by its setting"
+inputs:
+  dockerFile:  # Docker filename to build
+    description: "Dockerfile to build"
+    required: true
+    default: "docker/chrome/Dockerfile"
+  imageName:
+    description: "Image name for tagging"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+
+    - name: Build image
+      run: docker build . --file ${{ input.dockerFile }} --tag ${{ input.imageName }}
+
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u $DOCKER_LOGIN --password-stdin
+
+    - name: Push image
+      run: |
+        IMAGE_ID=appvantage/${{ input.imageName }}
+
+        # Change all uppercase to lowercase
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "master" ] && VERSION=latest
+
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+
+        docker tag ${{ input.imageName }} $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,32 +47,14 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Build image for chrome
+        uses: ./.github/actions/docker-build
+        with:
+          dockerFile: docker/chrome/Dockerfile
+          imageName: $IMAGE_NAME
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
-
-      - name: Log into registry
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u $DOCKER_LOGIN --password-stdin
-
-      - name: Push image
-        run: |
-          IMAGE_ID=appvantage/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      - name: Build image for chromium
+        uses: ./.github/actions/docker-build
+        with:
+          dockerFile: docker/chromium/Dockerfile
+          imageName: $IMAGE_NAME-chromium

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -40,6 +40,8 @@ RUN apt-get update \
      # (https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix)
      # but that seems too easy to get out of date.
      && apt-get install -y google-chrome-stable \
+     # Font installation, support chinese font characters for now
+     && apt-get install -y fonts-wqy-zenhei \
      && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/app

--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:18.3.0-bullseye-slim as build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/app
+
+ENV NODE_ENV=development
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+COPY yarn.lock package.json ./
+
+RUN yarn install --frozen-lockfile
+
+COPY tsconfig.json ./
+COPY src ./src
+
+RUN yarn build
+
+ENV NODE_ENV=production
+
+# install dependencies with frozen lockfile
+# then clean with node prune
+RUN yarn install --frozen-lockfile --production
+
+# install node prune
+RUN curl -sf https://gobinaries.com/tj/node-prune | sh
+
+FROM node:18.3.0-bullseye-slim
+
+RUN apt-get update \
+     && apt-get install -y wget gnupg ca-certificates procps libxss1 \
+     && apt-get update \
+     # For ARM, google-chrome-stable is not available
+     # and M1 failed to emulate the chrome browser.
+     # thus we use chromium for this
+     && apt-get install -y chromium \
+     # Font settings, currently support for chinese characters
+     && apt-get install -y fonts-wqy-zenhei \
+     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/app
+
+ENV PORT=3000
+ENV NODE_ENV=production
+# ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+COPY --from=build /usr/local/app/node_modules ./node_modules
+COPY --from=build /usr/local/app/build ./
+
+CMD node index.js


### PR DESCRIPTION
### Description

For AFC, there is a need to install chinese font characters. But, during debugging process, M1 users like me, can't use the image, and have to use `chromium` instead of `chrome`. So, this PR include docker build for `chrome` (previous one) and `chromium` the new one, with additional font installation for chinese characters inside both `Dockerfile`

### Concerns

- Is it only chinese characters to install? Should we include other font as well?
- Is there any possibility to test github actions locally? I saw `https://github.com/nektos/act`, but haven't try it yet.

### Changes

- Move `Dockerfile` to `docker` directory, for `chrome` and `chromium` respectively
- Create github actions under `.github/actions` for build docker image, since we will build 2 images
- Update `docker-publish.yml` to use customized github actions `docker-build.yml`