### PR TITLE
ci: try resolve load locally custom gh-action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,9 @@ jobs:
       packages: write
 
     steps:
+      # Use actions/checkout before using local action loader
+      # https://github.community/t/path-to-action-in-the-same-repository-as-workflow/16952/2
+      - uses: actions/checkout@v3
       - name: Build image for chrome
         uses: ./.github/actions/docker-build
         with:


### PR DESCRIPTION
### Description

For custom github action to load, let's try to use `actions/checkout` first before loading it.
Reference: https://github.community/t/path-to-action-in-the-same-repository-as-workflow/16952/2

If it still doesn't worked, I think I will put duplicated step for build 2 image in `workflow.yml`

