### PR TITLE
feat: allow custom values for body limit

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,8 +14,10 @@ app.disable('x-powered-by');
 
 // enable compression
 app.use(compression());
+
 // and json parsing
-app.use(express.json());
+const bodyLimit = process.env.BODY_LIMIT || '100kb';
+app.use(express.json({ limit: bodyLimit }));
 
 // enable logs
 app.use(morgan(process.env.NODE_ENV === 'production' ? 'tiny' : 'dev'));


### PR DESCRIPTION
Read body limit from environment variable `BODY_LIMIT` to configure the body limiter on the body parser library. The value can either be a number of bits or a string to be parsed by the bytes.js library.