### PR TITLE
feat: add font-thai support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,8 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Build chrome image
         run: docker build . --file docker/chrome/Dockerfile --tag $IMAGE_NAME
@@ -77,6 +78,26 @@ jobs:
 
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
+
+  # Build chromium image in docker
+  push-chromium:
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/arm64
 
       - name: Build chromium image
         run: docker build . --file docker/chromium/Dockerfile --platform linux/arm64 --tag $IMAGE_CHROMIUM

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -41,8 +41,8 @@ RUN apt-get update \
      # (https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#chrome-headless-doesnt-launch-on-unix)
      # but that seems too easy to get out of date.
      && apt-get install -y google-chrome-stable \
-     # Font installation, support chinese font characters for now
-     && apt-get install -y fonts-wqy-zenhei fonts-indic fonts-noto fonts-noto-cjk \
+     # Font installation, support chinese, japanese, korean, hindi, and thai for now
+     && apt-get install -y fonts-wqy-zenhei fonts-indic fonts-noto fonts-noto-cjk fonts-thai-tlwg-ttf \
      && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/app

--- a/docker/chromium/Dockerfile
+++ b/docker/chromium/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update \
      # and M1 failed to emulate the chrome browser.
      # thus we use chromium for this
      && apt-get install -y chromium \
-     # Font settings, currently support for chinese characters
-     && apt-get install -y fonts-wqy-zenhei fonts-indic fonts-noto fonts-noto-cjk  \
+     # Font installation, support chinese, japanese, korean, hindi, and thai for now
+     && apt-get install -y fonts-wqy-zenhei fonts-indic fonts-noto fonts-noto-cjk fonts-thai-tlwg-ttf \
      && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/local/app


### PR DESCRIPTION
## Description

Added support for Thai font. Along the way, I tried to add QEMU, to see if github action can build for `arm64` (with chromium). Will take a look later for `docker manifest`, to combine build 2 different docker file with different platform target and push on the same tag. But, haven't manage to do it using my own account. And, `docker manifest` seems experimental too.