### PR TITLE
fix: resolve forgotten docker login step

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Build chromium image
         run: docker build . --file docker/chromium/Dockerfile --platform linux/arm64 --tag $IMAGE_CHROMIUM
 
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u $DOCKER_LOGIN --password-stdin
+
       - name: Push chromium image
         run: |
           IMAGE_ID=appvantage/$IMAGE_NAME


### PR DESCRIPTION
## Description

Build for chromium successful! But, push to docker step fail due to forgotten login step, added in this PR.